### PR TITLE
Fix usage of `spglib`

### DIFF
--- a/elastic/elastic.py
+++ b/elastic/elastic.py
@@ -331,9 +331,8 @@ def get_lattice_type(cryst):
             [231, "Cubic"]
         ]
 
-    sg = spg.get_spacegroup((cryst.get_cell(), 
-                             cryst.get_positions(), 
-                             cryst.numbers))
+    cell = (cryst.cell, cryst.get_scaled_positions(), cryst.numbers)
+    sg = spg.get_spacegroup(cell)
     m = re.match(r'([A-Z].*\b)\s*\(([0-9]*)\)', sg)
     sg_name = m.group(1)
     sg_nr = int(m.group(2))

--- a/elastic/elastic.py
+++ b/elastic/elastic.py
@@ -63,7 +63,6 @@ There is some usefull summary also at:
 '''
 
 from __future__ import print_function, division, absolute_import
-import re
 from ase.atoms import Atoms
 
 try:
@@ -332,10 +331,9 @@ def get_lattice_type(cryst):
         ]
 
     cell = (cryst.cell, cryst.get_scaled_positions(), cryst.numbers)
-    sg = spg.get_spacegroup(cell)
-    m = re.match(r'([A-Z].*\b)\s*\(([0-9]*)\)', sg)
-    sg_name = m.group(1)
-    sg_nr = int(m.group(2))
+    dataset = spg.get_symmetry_dataset(cell)
+    sg_name = dataset['international']
+    sg_nr = dataset['number']
 
     for n, l in enumerate(lattice_types):
         if sg_nr < l[0]:


### PR DESCRIPTION
There is a bug in the present master introduced in b88c51c39b5350ad6492afcead861794908c3afd

For the following POSCAR file with the space group type of `I4/m`
```
generated by phonopy
   1.0
     5.7424952469569419    0.0000000000000000    0.0000000000000000
     0.0000000000000000    5.7424952469569419    0.0000000000000000
     0.0000000000000000    0.0000000000000000    3.5536083410560715
Ni W
   8    2
Direct
  0.5996722148177035  0.8006704283160834  0.0000000000000000
  0.3006704283160833  0.9003277851822965  0.5000000000000000
  0.6993295716839166  0.0996722148177036  0.5000000000000000
  0.4003277851822965  0.1993295716839166  0.0000000000000000
  0.0996722148177036  0.3006704283160833  0.5000000000000000
  0.8006704283160833  0.4003277851822964  0.0000000000000000
  0.1993295716839167  0.5996722148177036  0.0000000000000000
  0.9003277851822965  0.6993295716839166  0.5000000000000000
  0.0000000000000000  0.0000000000000000  0.0000000000000000
  0.5000000000000000  0.5000000000000000  0.5000000000000000
```
the following script
```python
import ase.io
import spglib as spg
from elastic.elastic import get_lattice_type

atoms = ase.io.read("POSCAR")
cell = (atoms.cell, atoms.get_scaled_positions(), atoms.numbers)
print(spg.get_spacegroup(cell))
# print(spg.get_symmetry_dataset(cell))
print(get_lattice_type(atoms))
```
gives at this moment
```
I4/m (87)
(1, 'Triclinic', 'P1', 1)
```
meaning the Elastic does not detect the space group correctly.

The reason of this bug is because in spglib we must give "fractional" coordinates, while presently cartesian coordinates are given. (https://spglib.readthedocs.io/en/stable/python-interface.html#crystal-structure-cell)

The present PR fixes this. With this, the code above correctly gives
```
I4/m (87)
(4, 'Tetragonal', 'I4/m', 87)
```

I would also like to suggest using `spg.get_symmetry_dataset` rather than parsing the string of space group type and number on the Elastic side.

Thank you so much @jochym for your kind review in advance!